### PR TITLE
Use ssh-agent in CI for ED25519 deploy key

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -47,12 +47,15 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-      - name: Setup SSH
+      - name: Setup SSH agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_DEPLOY_KEY }}
+      - name: Setup known_hosts
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_DEPLOY_KEY }}" > ~/.ssh/id_ed25519
-          chmod 600 ~/.ssh/id_ed25519
           echo "${{ secrets.SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
       - name: Deploy to integration
         env:
           DEPLOY_INTEGRATION_HOST: ${{ secrets.DEPLOY_INTEGRATION_HOST }}


### PR DESCRIPTION
## Summary

Behebt den Fehler `OpenSSH keys only supported if ED25519 is available` im `deploy_integration`-Job.

Der Workflow legte den Deploy-Key bisher als Datei ab. Net-ssh musste den ED25519-Private-Key dann in Ruby selbst parsen und scheiterte daran (es bräuchte die Gems `ed25519` und `bcrypt_pbkdf`).

Lokal hat das nie geknallt, weil dort der `ssh-agent` läuft. Net-ssh spricht nur den Agent-Socket; die ED25519-Krypto macht der Agent. Mit `webfactory/ssh-agent` gleicht sich CI an dieses Verhalten an – ohne zwei zusätzliche Dev-Gems in die App zu ziehen.

## Test plan

- [ ] Push auf `main` triggert erfolgreichen `deploy_integration`-Job

🤖 Generated with [Claude Code](https://claude.com/claude-code)