### PR TITLE
Add temporary SSH debug step to deploy_integration

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -56,6 +56,20 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
           chmod 600 ~/.ssh/known_hosts
+      - name: Debug SSH (TEMPORARY)
+        env:
+          DEPLOY_INTEGRATION_HOST: ${{ secrets.DEPLOY_INTEGRATION_HOST }}
+          DEPLOY_INTEGRATION_USER: ${{ secrets.DEPLOY_INTEGRATION_USER }}
+        run: |
+          echo "=== Loaded keys in ssh-agent ==="
+          ssh-add -l || echo "no keys loaded"
+          echo "=== known_hosts ==="
+          wc -l ~/.ssh/known_hosts
+          cut -d' ' -f1 ~/.ssh/known_hosts | sort -u
+          echo "=== Test SSH (verbose) ==="
+          ssh -vvv -o BatchMode=yes -o ConnectTimeout=10 \
+              "$DEPLOY_INTEGRATION_USER@$DEPLOY_INTEGRATION_HOST" \
+              'echo OK from $(whoami)@$(hostname)' 2>&1 || echo "ssh exit $?"
       - name: Deploy to integration
         env:
           DEPLOY_INTEGRATION_HOST: ${{ secrets.DEPLOY_INTEGRATION_HOST }}


### PR DESCRIPTION
## Summary

Temporärer Diagnostic-Step vor dem `cap deploy`-Aufruf, um die Ursache des aktuellen `Net::SSH::AuthenticationFailed` einzugrenzen:

- `ssh-add -l` → wird der Key vom Secret korrekt in den Agent geladen?
- `ssh -vvv … echo OK` → welche Keys werden angeboten, was akzeptiert der Server, finale Fehlerursache?

## Diagnose-Matrix

- `ssh-add -l` leer → `SSH_DEPLOY_KEY`-Secret reparieren (Format/Newline)
- Fingerprint passt nicht zum lokalen `ssh-keygen -lf <key>.pub` → falscher Key im Secret
- `Permission denied (publickey)` → Public-Key fehlt in `authorized_keys` auf Server, oder User stimmt nicht
- `Authenticated to …` mit nachfolgendem Fehler → Auth funktioniert, anderes Problem

## Cleanup

Nach Diagnose & Fix: Folge-PR der diesen Step wieder entfernt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)