### PR TITLE
Add ed25519 + bcrypt_pbkdf gems for net-ssh ED25519 auth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,9 @@ group :development do
   gem 'capistrano', '~> 3.18'
   gem 'capistrano-rails'
   gem 'capistrano-bundler'
+  # Required by net-ssh for ED25519 SSH key authentication, even via ssh-agent
+  gem 'ed25519', '~> 1.2'
+  gem 'bcrypt_pbkdf', '~> 1.0'
 end
 
 # Reduces boot times through caching; required in config/boot.rb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
     autoprefixer-rails (10.4.19.0)
       execjs (~> 2)
     base64 (0.3.0)
+    bcrypt_pbkdf (1.1.2)
     benchmark (0.5.0)
     bigdecimal (4.1.2)
     bindex (0.8.1)
@@ -140,6 +141,7 @@ GEM
       dotenv (= 3.2.0)
       railties (>= 6.1)
     drb (2.2.3)
+    ed25519 (1.4.0)
     erb (6.0.4)
     erubi (1.13.1)
     execjs (2.10.0)
@@ -361,6 +363,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotate
+  bcrypt_pbkdf (~> 1.0)
   bootsnap (>= 1.1.0)
   bootstrap
   brakeman (~> 5.4)
@@ -372,6 +375,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   coffee-rails
   dotenv-rails
+  ed25519 (~> 1.2)
   factory_bot_rails (~> 4.0)
   jquery-rails
   listen (>= 3.0.5, < 3.2)


### PR DESCRIPTION
## Summary

Behebt das paradoxe Authentifizierungsverhalten im `deploy_integration`-Job: OpenSSH-CLI authentifiziert mit dem Deploy-Key über den ssh-agent erfolgreich (Debug-Step zeigt `Authenticated to ***`), aber Net-SSH (Capistrano) scheitert direkt danach mit `Net::SSH::AuthenticationFailed`.

Ursache: Net-SSH 7.x benötigt für ED25519-Keys die Ruby-Gems `ed25519` und `bcrypt_pbkdf` – auch wenn der Schlüssel über den ssh-agent kommt. Ohne sie kann Net-SSH den ED25519-Public-Key-Blob, den der Agent zurückgibt, nicht zur Auth-Negotiation verwenden.

## Test plan

- [x] `bundle install` → installiert ed25519 1.4.0, bcrypt_pbkdf 1.1.2
- [x] `bundle-audit check` → No vulnerabilities found
- [x] `bundle exec rails test` → 57 runs, 0 failures, 0 errors
- [ ] Nach Merge: `deploy_integration`-Job läuft erstmals durch

🤖 Generated with [Claude Code](https://claude.com/claude-code)