### PR TITLE
Fix blank Plotly graphs on first Turbo visit

### DIFF
--- a/app/views/layouts/mensajasser.html.erb
+++ b/app/views/layouts/mensajasser.html.erb
@@ -16,7 +16,7 @@
     <%= javascript_importmap_tags %>
 	
 	<%- if (@page_specific_js_libraries || []).include?('plotly') %>
-	    <script type="text/javascript" src="/plotly-latest.min.js"></script>
+	    <script type="text/javascript" src="/plotly-latest.min.js" data-turbo-track="reload"></script>
 	<% end -%>
   </head>
 


### PR DESCRIPTION
## Problem
On graph pages (e.g. `/graph/year`) the Plotly chart was blank on the **first** visit reached via Turbo navigation, with no visible error. Reloading the page (or visiting another graph page afterwards) worked.

## Cause
Each graph view builds its chart in an inline `<body>` `<script>` that calls `Plotly.plot`, while the Plotly library is loaded conditionally in the `<head>` only on graph pages. On a full page load the head `<script>` is blocking and runs before the body, so `Plotly` is defined in time. Under Turbo Drive, Turbo appends the new head `<script>` **asynchronously** and renders the body immediately, so the inline script runs before Plotly has loaded → `Plotly` is undefined, the call throws in the console, and the chart stays blank. Once Plotly is cached in the persisted head, later visits work — matching the reported symptom.

## Fix
Mark the Plotly `<script>` with `data-turbo-track="reload"`. Turbo then does a full page reload when entering (or leaving) a graph page, where the tracked script is present only then, so Plotly loads synchronously before the body again. Navigation **between** graph pages stays a fast Turbo visit (tracked set unchanged, Plotly already loaded).

## Verification
Confirmed in the browser: the graph now renders on the first Turbo navigation to a graph page.