### PR TITLE
Bump concurrent-ruby to 1.3.7 for CVE fixes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     crass (1.0.6)
     date (3.5.1)


### PR DESCRIPTION
## Why

CI's `lint` job fails on every branch because `bundler-audit` flags
`concurrent-ruby 1.3.6`:

- CVE-2026-54904 — `AtomicReference#update` livelocks on `Float::NAN`
- CVE-2026-54905 — `ReentrantReadWriteLock` read-count overflow
- CVE-2026-54906 — read-write lock wrong-thread release / counter corruption

All resolved in `>= 1.3.7`.

## What

`concurrent-ruby` is a transitive dependency (via `activesupport`), so
only `Gemfile.lock` changes: `1.3.6` → `1.3.7`.

This is independent of #93 (nokogiri bump). Merging both clears the
audit completely.