### PR TITLE
Bump crass to 1.0.7 for security advisory

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
       xpath (~> 3.2)
     concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
-    crass (1.0.6)
+    crass (1.0.7)
     date (3.5.1)
     dotenv (3.2.0)
     dotenv-rails (3.2.0)


### PR DESCRIPTION
crass 1.0.6 is flagged by bundler-audit (advisories published
2026-06-28), which fails the `lint` job on every branch — including
the open Dependabot PR #96 (trilogy):

- GHSA-6jxj-px6v-747w — deeply nested CSS → SystemStackError / memory
- GHSA-6wmf-3r64-vcwv — large numeric exponents → CPU/memory DoS
- GHSA-8vfg-2r28-hvhj — non-ASCII chars → superlinear CPU
- GHSA-wwpr-jff3-395c — many adjacent comments → SystemStackError

Conservatively bumps the transitive `loofah` dependency to 1.0.7,
which satisfies its `~> 1.0.2` constraint. `bin/bundler-audit`
reports no vulnerabilities after the change.